### PR TITLE
Avoid looping operation

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,6 +68,7 @@ go get github.com/yale8848/stream@v1.3.1
 - [x] Count
 - [ ] iterator
 - [x] Sum
+- [x] Reduce
 
 
 ### Short-circuiting

--- a/example/stream_test.go
+++ b/example/stream_test.go
@@ -108,3 +108,26 @@ func TestSum(t *testing.T)  {
 		return int64(v1.age)
 	}))
 }
+
+
+func TestReduce(t *testing.T) {
+	s, _ := stream.Of(data)
+	reduce := s.Filter(func(v stream.T) bool {
+		return v.(person).age > 5
+	}).Reduce(0, func(x, y stream.T) stream.T {
+		return x.(int) + y.(person).age
+	})
+	fmt.Printf("TestReduce result is %d", reduce)
+}
+
+func TestReduce2(t *testing.T) {
+	s, _ := stream.Of(data)
+	reduce := s.Filter(func(v stream.T) bool {
+		return v.(person).age > 5
+	}).Map(func(v stream.T) stream.T {
+		return v.(person).age
+	}).Reduce(0, func(x, y stream.T) stream.T {
+		return x.(int) + y.(int)
+	})
+	fmt.Printf("TestReduce2 result is %d", reduce)
+}

--- a/reduce.go
+++ b/reduce.go
@@ -1,0 +1,19 @@
+package stream
+
+type reduce struct {
+	r        BinaryOperator
+	identity T
+	result   T
+}
+
+func (sk *reduce) Begin(size int64) {
+	sk.result = sk.identity
+}
+func (sk *reduce) Accept(t T) {
+	sk.result = sk.r(sk.result, t)
+}
+func (sk *reduce) End() {
+}
+func (sk *reduce) CancellationRequested() bool {
+	return false
+}

--- a/stream.go
+++ b/stream.go
@@ -38,6 +38,8 @@ type Less func(v1, v2 T) bool
 type MinCompare func(min T, v T) bool
 type MaxCompare func(max T, v T) bool
 
+type BinaryOperator func(x, y T) T
+
 type stream struct {
 	values reflect.Value
 	link *sinkNode
@@ -71,6 +73,7 @@ type Stream interface {
 	Min(min MinCompare)T
 	Max(max MaxCompare)T
 	Sum(s Sum)int64
+	Reduce(identity T, r BinaryOperator) T
 
 	//Short-circuiting
 	FindFirst()T
@@ -258,4 +261,12 @@ func (stm *stream) Count() int64 {
 	stm.link.next = n
 	stm.do()
 	return sk.num
+}
+
+func (stm *stream) Reduce(identity T, r BinaryOperator) T {
+	sk:=&reduce{identity: identity, r: r}
+	n:=&sinkNode{value:sk}
+	stm.link.next = n
+	stm.do()
+	return sk.result
 }

--- a/stream.go
+++ b/stream.go
@@ -39,7 +39,7 @@ type MinCompare func(min T, v T) bool
 type MaxCompare func(max T, v T) bool
 
 type stream struct {
-	values []T
+	values reflect.Value
 	link *sinkNode
 	head *sinkNode
 }
@@ -123,13 +123,7 @@ func Of(arr T) (Stream,error) {
 
 	tp := reflect.TypeOf(arr)
 	if tp.Kind() == reflect.Array || tp.Kind() == reflect.Slice {
-		arrValue := reflect.ValueOf(arr)
-		values := make([]T, arrValue.Len())
-		for i := 0; i < len(values); i++ {
-			v := arrValue.Index(i)
-			values[i] = v.Interface()
-		}
-		stm.values = values
+		stm.values = reflect.ValueOf(arr)
 	}else{
 		return nil,errors.New("value must Array or Slice")
 	}
@@ -247,11 +241,9 @@ func (stm *stream) Map(f Function) Stream {
 func (stm *stream)do(){
 
 	stm.head.next.value.Begin(-1)
-	for _,v:=range stm.values{
-		stm.head.next.value.Accept(v)
+	for i := 0; i < stm.values.Len(); i++ {
+		stm.head.next.value.Accept(stm.values.Index(i).Interface())
 	}
-	stm.head.next.value.End()
-
 }
 func (stm *stream) ForEach(c ConsumerCancel) {
 	sk:=&foreach{cons:c}


### PR DESCRIPTION
- The struct `stream` just holds the reflect.Value of data source.
- add reduce operation 